### PR TITLE
OSX Compilation Fix

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,8 +9,8 @@ cd env/python
 
 if [ "$(uname -s)" == "Darwin" ]; then
     export MACOSX_DEPLOYMENT_TARGET="10.15"
+    export CMAKE_ARGS="-DCMAKE_C_FLAGS=-Wno-c++11-narrowing -DCMAKE_CXX_FLAGS=-Wno-c++11-narrowing"
 fi
 
-export CMAKE_ARGS="-DCMAKE_C_FLAGS=--no-pedantic -DCMAKE_CXX_FLAGS=--no-pedantic"
 
 ${PYTHON} -m pip install . -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,4 +11,6 @@ if [ "$(uname -s)" == "Darwin" ]; then
     export MACOSX_DEPLOYMENT_TARGET="10.15"
 fi
 
+export CMAKE_ARGS="-DCMAKE_C_FLAGS=--no-pedantic -DCMAKE_CXX_FLAGS=--no-pedantic"
+
 ${PYTHON} -m pip install . -vv


### PR DESCRIPTION
Added '-Wno-c++11-narrowing' to cflags/cxxflags to turn off the compilation error on OSX. Haven't run tests, but compilation appears to pass.

Run logs at: https://github.com/conda-forge/srwpy-feedstock/pull/13/commits/046a5df9dd57f30d6531b147b34fa5dd6638ba05